### PR TITLE
feat: add SPDX license headers to all Go files

### DIFF
--- a/cmd/slurm-exporter/main.go
+++ b/cmd/slurm-exporter/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package main
 
 import (

--- a/cmd/slurm-exporter/main_test.go
+++ b/cmd/slurm-exporter/main_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package main
 
 import (

--- a/cmd/slurm-exporter/shutdown.go
+++ b/cmd/slurm-exporter/shutdown.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package main
 
 import (

--- a/cmd/slurm-exporter/shutdown_test.go
+++ b/cmd/slurm-exporter/shutdown_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package main
 
 import (

--- a/cmd/validate-config/main.go
+++ b/cmd/validate-config/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package main
 
 import (

--- a/internal/adaptive/integration_example.go
+++ b/internal/adaptive/integration_example.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package adaptive
 
 import (

--- a/internal/adaptive/scheduler.go
+++ b/internal/adaptive/scheduler.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package adaptive
 
 import (

--- a/internal/adaptive/scheduler_test.go
+++ b/internal/adaptive/scheduler_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package adaptive
 
 import (

--- a/internal/batch/batch_integration.go
+++ b/internal/batch/batch_integration.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package batch
 
 import (

--- a/internal/collector/access_validation.go
+++ b/internal/collector/access_validation.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/account.go
+++ b/internal/collector/account.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/account_cost_tracking.go
+++ b/internal/collector/account_cost_tracking.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/account_hierarchy.go
+++ b/internal/collector/account_hierarchy.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/account_performance_benchmark.go
+++ b/internal/collector/account_performance_benchmark.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/account_quota.go
+++ b/internal/collector/account_quota.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/account_usage_patterns.go
+++ b/internal/collector/account_usage_patterns.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/accounts_simple.go
+++ b/internal/collector/accounts_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/accounts_simple_test.go
+++ b/internal/collector/accounts_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/anomaly_detection_streaming.go
+++ b/internal/collector/anomaly_detection_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/associations_simple.go
+++ b/internal/collector/associations_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/associations_simple_test.go
+++ b/internal/collector/associations_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/base.go
+++ b/internal/collector/base.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/base_test.go
+++ b/internal/collector/base_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/bottleneck_analyzer.go
+++ b/internal/collector/bottleneck_analyzer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/cluster.go
+++ b/internal/collector/cluster.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/cluster_health_streaming.go
+++ b/internal/collector/cluster_health_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/cluster_simple.go
+++ b/internal/collector/cluster_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/cluster_simple_test.go
+++ b/internal/collector/cluster_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/cluster_test.go
+++ b/internal/collector/cluster_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/clusters_simple.go
+++ b/internal/collector/clusters_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/clusters_simple_test.go
+++ b/internal/collector/clusters_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/common_types.go
+++ b/internal/collector/common_types.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import "time"

--- a/internal/collector/concurrent.go
+++ b/internal/collector/concurrent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/concurrent_test.go
+++ b/internal/collector/concurrent_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/degradation.go
+++ b/internal/collector/degradation.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/degradation_test.go
+++ b/internal/collector/degradation_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/degraded_collector.go
+++ b/internal/collector/degraded_collector.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/degraded_collector_test.go
+++ b/internal/collector/degraded_collector_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/diagnostics_simple.go
+++ b/internal/collector/diagnostics_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/diagnostics_simple_test.go
+++ b/internal/collector/diagnostics_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/efficiency_calculator.go
+++ b/internal/collector/efficiency_calculator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/energy_monitor.go
+++ b/internal/collector/energy_monitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/errors.go
+++ b/internal/collector/errors.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/errors_test.go
+++ b/internal/collector/errors_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/event_aggregation_correlation.go
+++ b/internal/collector/event_aggregation_correlation.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/fairshare.go
+++ b/internal/collector/fairshare.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/fairshare_decay.go
+++ b/internal/collector/fairshare_decay.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/fairshare_policy_effectiveness.go
+++ b/internal/collector/fairshare_policy_effectiveness.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/fairshare_trend_reporting.go
+++ b/internal/collector/fairshare_trend_reporting.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/fairshare_violations.go
+++ b/internal/collector/fairshare_violations.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/instrumented.go
+++ b/internal/collector/instrumented.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/interface.go
+++ b/internal/collector/interface.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_analytics_engine.go
+++ b/internal/collector/job_analytics_engine.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_performance.go
+++ b/internal/collector/job_performance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_performance_simplified.go
+++ b/internal/collector/job_performance_simplified.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_priority.go
+++ b/internal/collector/job_priority.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_scheduling_streaming.go
+++ b/internal/collector/job_scheduling_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_step_performance.go
+++ b/internal/collector/job_step_performance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/jobs_simple.go
+++ b/internal/collector/jobs_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/jobs_simple_test.go
+++ b/internal/collector/jobs_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/label_helper.go
+++ b/internal/collector/label_helper.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/label_helper_test.go
+++ b/internal/collector/label_helper_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/licenses_simple.go
+++ b/internal/collector/licenses_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/licenses_simple_test.go
+++ b/internal/collector/licenses_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/live_job_monitor.go
+++ b/internal/collector/live_job_monitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/logging.go
+++ b/internal/collector/logging.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/logging_test.go
+++ b/internal/collector/logging_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/metric_filter.go
+++ b/internal/collector/metric_filter.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/node_state_streaming.go
+++ b/internal/collector/node_state_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/node_test.go
+++ b/internal/collector/node_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/nodes_simple.go
+++ b/internal/collector/nodes_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/nodes_simple_test.go
+++ b/internal/collector/nodes_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/partition.go
+++ b/internal/collector/partition.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/partition_resource_streaming.go
+++ b/internal/collector/partition_resource_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/partition_test.go
+++ b/internal/collector/partition_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/partitions_simple.go
+++ b/internal/collector/partitions_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/partitions_simple_test.go
+++ b/internal/collector/partitions_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/performance.go
+++ b/internal/collector/performance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/performance_benchmarking.go
+++ b/internal/collector/performance_benchmarking.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/performance_monitor.go
+++ b/internal/collector/performance_monitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/performance_simple.go
+++ b/internal/collector/performance_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/performance_simple_test.go
+++ b/internal/collector/performance_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/priority_factors.go
+++ b/internal/collector/priority_factors.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/profiled_collector.go
+++ b/internal/collector/profiled_collector.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/profiled_collector_test.go
+++ b/internal/collector/profiled_collector_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/qos.go
+++ b/internal/collector/qos.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/qos_limits.go
+++ b/internal/collector/qos_limits.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/qos_test.go
+++ b/internal/collector/qos_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/queue_analysis.go
+++ b/internal/collector/queue_analysis.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/queue_state_streaming.go
+++ b/internal/collector/queue_state_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/quota_compliance.go
+++ b/internal/collector/quota_compliance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/realtime_job_streaming.go
+++ b/internal/collector/realtime_job_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/registry.go
+++ b/internal/collector/registry.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/registry_test.go
+++ b/internal/collector/registry_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/reservation.go
+++ b/internal/collector/reservation.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/reservation_test.go
+++ b/internal/collector/reservation_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/reservation_utilization.go
+++ b/internal/collector/reservation_utilization.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/resource_trend_tracker.go
+++ b/internal/collector/resource_trend_tracker.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/selfmon.go
+++ b/internal/collector/selfmon.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/shares_simple.go
+++ b/internal/collector/shares_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/shares_simple_test.go
+++ b/internal/collector/shares_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/system_simple.go
+++ b/internal/collector/system_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/system_simple_test.go
+++ b/internal/collector/system_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/task_utilization_monitor.go
+++ b/internal/collector/task_utilization_monitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/tres_simple.go
+++ b/internal/collector/tres_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/tres_simple_test.go
+++ b/internal/collector/tres_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/user.go
+++ b/internal/collector/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/user_behavior_analysis.go
+++ b/internal/collector/user_behavior_analysis.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/user_permission_audit.go
+++ b/internal/collector/user_permission_audit.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/user_test.go
+++ b/internal/collector/user_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/users_simple.go
+++ b/internal/collector/users_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/users_simple_test.go
+++ b/internal/collector/users_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/wckeys_simple.go
+++ b/internal/collector/wckeys_simple.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/wckeys_simple_test.go
+++ b/internal/collector/wckeys_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/collector/workload_pattern_streaming.go
+++ b/internal/collector/workload_pattern_streaming.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package collector
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package config
 
 import (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package config
 
 import (

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package config
 
 import (

--- a/internal/config/validation_simple_test.go
+++ b/internal/config/validation_simple_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package config
 
 import (

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package config
 
 import (

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package config
 
 import (

--- a/internal/filtering/integration_example.go
+++ b/internal/filtering/integration_example.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package filtering
 
 import (

--- a/internal/filtering/smart_filter.go
+++ b/internal/filtering/smart_filter.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package filtering
 
 import (

--- a/internal/filtering/smart_filter_test.go
+++ b/internal/filtering/smart_filter_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package filtering
 
 import (

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package health
 
 import (

--- a/internal/health/checks_test.go
+++ b/internal/health/checks_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package health
 
 import (

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package health
 
 import (

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package integration
 
 import (

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package logging
 
 import (

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package logging
 
 import (

--- a/internal/metrics/cardinality.go
+++ b/internal/metrics/cardinality.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/cardinality_test.go
+++ b/internal/metrics/cardinality_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/definitions.go
+++ b/internal/metrics/definitions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/docgen.go
+++ b/internal/metrics/docgen.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/labels.go
+++ b/internal/metrics/labels.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/labels_test.go
+++ b/internal/metrics/labels_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/metadata.go
+++ b/internal/metrics/metadata.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/metadata_test.go
+++ b/internal/metrics/metadata_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/monitor.go
+++ b/internal/metrics/monitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/performance.go
+++ b/internal/metrics/performance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/metrics/performance_test.go
+++ b/internal/metrics/performance_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package metrics
 
 import (

--- a/internal/performance/batch_processor.go
+++ b/internal/performance/batch_processor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/batch_processor_test.go
+++ b/internal/performance/batch_processor_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/cache.go
+++ b/internal/performance/cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/cardinality_optimizer.go
+++ b/internal/performance/cardinality_optimizer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/connection_pool.go
+++ b/internal/performance/connection_pool.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/intelligent_cache.go
+++ b/internal/performance/intelligent_cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/intelligent_cache_example.go
+++ b/internal/performance/intelligent_cache_example.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/intelligent_cache_test.go
+++ b/internal/performance/intelligent_cache_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/memory.go
+++ b/internal/performance/memory.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/metric_batcher.go
+++ b/internal/performance/metric_batcher.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/profile_storage.go
+++ b/internal/performance/profile_storage.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/profiler.go
+++ b/internal/performance/profiler.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/performance/profiler_test.go
+++ b/internal/performance/profiler_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package performance
 
 import (

--- a/internal/resilience/circuit_breaker.go
+++ b/internal/resilience/circuit_breaker.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package resilience
 
 import (

--- a/internal/resilience/circuit_breaker_test.go
+++ b/internal/resilience/circuit_breaker_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package resilience
 
 import (

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package server
 
 import (

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package server
 
 import (

--- a/internal/server/profiling_debug.go
+++ b/internal/server/profiling_debug.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package server
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package server
 
 import (

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package server
 
 import (

--- a/internal/slurm/auth/auth.go
+++ b/internal/slurm/auth/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package auth
 
 import (

--- a/internal/slurm/auth/auth_test.go
+++ b/internal/slurm/auth/auth_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package auth
 
 import (

--- a/internal/slurm/client.go
+++ b/internal/slurm/client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package slurm
 
 import (

--- a/internal/slurm/client_test.go
+++ b/internal/slurm/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package slurm
 
 import (

--- a/internal/testutil/file_utils.go
+++ b/internal/testutil/file_utils.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package testutil
 
 import (

--- a/internal/testutil/framework.go
+++ b/internal/testutil/framework.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package testutil
 
 import (

--- a/internal/testutil/generators.go
+++ b/internal/testutil/generators.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package testutil
 
 import (

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package testutil
 
 import (

--- a/internal/testutil/mock_slurm_client.go
+++ b/internal/testutil/mock_slurm_client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package testutil
 
 import (

--- a/internal/testutil/mocks/slurm_client.go
+++ b/internal/testutil/mocks/slurm_client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package mocks
 
 // Re-export the generated mocks with backward-compatible names

--- a/internal/testutil/performance.go
+++ b/internal/testutil/performance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package testutil
 
 import (

--- a/internal/tracing/integration_example.go
+++ b/internal/tracing/integration_example.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package tracing
 
 import (

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package tracing
 
 import (

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package tracing
 
 import (

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package version
 
 import (

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package version
 
 import (

--- a/scripts/add-spdx-headers.sh
+++ b/scripts/add-spdx-headers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Script to add SPDX license headers to Go files
+
+set -e
+
+HEADER="// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+"
+
+# Find all Go files that don't have SPDX headers
+while IFS= read -r file; do
+    # Skip generated files
+    if grep -q "Code generated" "$file" 2>/dev/null; then
+        echo "⏭️  Skipping generated file: $file"
+        continue
+    fi
+    
+    # Skip test fixtures and mock data
+    if [[ "$file" =~ /testdata/ ]] || [[ "$file" =~ /fixtures/ ]]; then
+        echo "⏭️  Skipping test fixture: $file"
+        continue
+    fi
+    
+    # Check if file already has SPDX header
+    if grep -q "SPDX-License-Identifier: Apache-2.0" "$file"; then
+        echo "✅ Already has header: $file"
+        continue
+    fi
+    
+    # Add header to file
+    echo "$HEADER" | cat - "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+    echo "➕ Added header: $file"
+    
+done < <(find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./.git/*")
+
+echo ""
+echo "✅ SPDX headers added to all Go files!"

--- a/test/benchmark/performance_benchmark_test.go
+++ b/test/benchmark/performance_benchmark_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package benchmark
 
 import (

--- a/test/integration/api_integration_test.go
+++ b/test/integration/api_integration_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 //go:build integration
 // +build integration
 

--- a/test/integration/benchmark_test.go
+++ b/test/integration/benchmark_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package integration
 
 import (

--- a/test/integration/rocky_cluster_test.go
+++ b/test/integration/rocky_cluster_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package integration
 
 import (

--- a/test/security/security_test.go
+++ b/test/security/security_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 SLURM Exporter Contributors
+
 package security
 
 import (


### PR DESCRIPTION
## Summary

Adds Apache-2.0 SPDX license headers to all 191 Go files for proper license compliance.

## Changes

- ✅ Added SPDX-License-Identifier: Apache-2.0 to all Go files
- ✅ Added Copyright notice for SLURM Exporter Contributors  
- ✅ Created `scripts/add-spdx-headers.sh` for automation
- ✅ Verified all files pass license check

## Impact

- Fully enables the license-check CI job (was non-blocking in PR #7)
- Ensures proper Apache 2.0 license compliance
- No functional changes - only added headers

## Testing

- ✅ All tests passing
- ✅ `scripts/check-spdx-headers.sh`: 191/191 files compliant
- ✅ No code changes, only headers added

## Follow-up

This completes task #1 from the improvement plan. Next steps:
- #2: Address security vulnerabilities (3 moderate from Dependabot)
- #3: Enable Phase 3 linters (goconst, godox, revive)
- #4: Improve test coverage
- #5: Reduce code complexity
- #6: Enhance documentation