### PR TITLE
feat: enable exhaustruct linter for config structs - Phase 7 Task 2 #24

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
     - cyclop
     - embeddedstructfieldcheck  # Embedded struct formatting is stylistic
     - err113
-    - exhaustruct
     - forbidigo
     - funcorder                 # Function ordering is developer's choice
     - gochecknoglobals
@@ -41,6 +40,10 @@ linters:
               desc: Use standard library errors package or fmt.Errorf with %w
     dogsled:
       max-blank-identifiers: 2
+    exhaustruct:
+      include:
+        - 'internal/config\.\w+Config$'
+        - 'internal/config\.\w+Options$'
     dupl:
       threshold: 120            # Phase 7: Reduced from 150
     goconst:


### PR DESCRIPTION
## Summary
Enabled exhaustruct linter selectively for configuration structs to ensure all fields are initialized.

## What's Changed
- Enabled exhaustruct linter (was previously disabled)
- Configured include patterns to target only Config and Options structs in internal/config package
- Added exhaustruct configuration to .golangci.yml

## Configuration
```yaml
exhaustruct:
  include:
    - 'internal/config\.\w+Config$'
    - 'internal/config\.\w+Options$'
```

## Impact
- All existing config structs already have complete field initialization
- **Zero violations** found - no refactoring needed
- Enforces best practices for future changes to configuration structures
- Prevents incomplete struct initialization bugs

## Testing & Validation
✅ All tests passing with race detection
✅ golangci-lint: 0 issues
✅ Build: SUCCESS
✅ No violations found

## Related Task
- Phase 7 Task 2 (slurm-exporter-4v4): Enable exhaustruct for config structs