### PR TITLE
fix: Update release workflow to respect branch protection rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
+  id-token: write
 
 jobs:
   validate-tag:


### PR DESCRIPTION
## Problem
The release workflow's 'Update Documentation' job was trying to push directly to main, which violates the repository's branch protection rules requiring all changes to go through pull requests.

Additionally, there's a known conflict between `actions/checkout@v4+` and `peter-evans/create-pull-request` when both try to manage git credentials - resulting in duplicate Authorization headers that GitHub API rejects.

Finally, the `peter-evans/create-pull-request` action requires explicit `pull-requests: write` permission to create pull requests.

## Solution
1. **Respect branch protection rules**: Use `peter-evans/create-pull-request` action instead of direct push

2. **Fix credential conflict**: Apply official recommended workaround from GitHub Issues #2299 and #2215:
   - Upgrade to `actions/checkout@v6`
   - Set `persist-credentials: false` to prevent automatic credential persistence

3. **Add required permissions**:
   - `pull-requests: write` - Required for peter-evans/create-pull-request to create PRs
   - `id-token: write` - Required for cosign keyless signing during release
   - These permissions are set both globally and at the job level for clarity

This fix is verified against the known issue pattern found in upstream slurm-client repository (PR #83).

## Impact
Release workflow will now:
- Respect all branch protection rules
- Create PRs for documentation updates instead of forcing direct commits
- Avoid authentication header conflicts
- Have proper permissions for all release operations
- Allow for review before merging documentation changes
- Complete successfully without GitHub API rejections