### PR TITLE
docs: Remove profiling configuration (feature not implemented)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -776,12 +776,6 @@ performance:
     # Connection pooling
     max_idle_connections: 100
     connection_lifetime: 30m
-    
-    # Memory profiling
-    profiling:
-      enabled: false
-      interval: 5m
-      threshold_mb: 100
 ```
 
 ## Observability Configuration
@@ -884,7 +878,6 @@ debug:
       status: true                      # /debug/status
       collectors: true                  # /debug/collectors
       cache: true                      # /debug/cache
-      profiling: true                  # /debug/profiling
       config: false                    # /debug/config (sensitive)
       traces: true                     # /debug/traces
       
@@ -893,33 +886,6 @@ debug:
       json: true
       html: true
       prometheus: true
-```
-
-### Collection Profiling
-```yaml
-debug:
-  profiling:
-    enabled: true
-    
-    # CPU profiling
-    cpu_profile_duration: 30s
-    cpu_profile_rate: 100               # Hz
-    
-    # Memory profiling
-    memory_profile_interval: 5m
-    memory_profile_rate: 512            # KB
-    
-    # Goroutine profiling
-    goroutine_profile_enabled: true
-    block_profile_enabled: true
-    mutex_profile_enabled: true
-    
-    # Storage configuration
-    storage:
-      type: "file"                      # file, memory, s3
-      path: "/tmp/profiles"
-      max_profiles: 100
-      retention: "24h"
 ```
 
 ## Logging Settings


### PR DESCRIPTION
## Summary

Removes all profiling configuration documentation from `docs/configuration.md` as the profiling feature is not currently integrated into the application.

## Documentation Review Findings

After thorough review of the documentation (specifically the performance view documentation as requested), I found that:

✅ **Accurate**: `docs/performance-monitoring.md` correctly documents the `/debug/performance` endpoint and matches the implementation in `internal/server/server.go`

❌ **Inaccurate**: Profiling documentation described configuration that doesn't exist:
- `observability.profiling` - `ObservabilityConfig` has no profiling field
- `performance.memory.profiling` - No top-level `performance` field in `Config`
- `debug.profiling` - `DebugConfig` has no profiling field

## Root Cause

The profiling functionality exists as library code (`internal/performance/profiler.go`) but is never instantiated or integrated:
- `NewProfiler()` is never called in production code
- `NewProfilingDebugHandler()` is never instantiated
- Profiling endpoints documented at `/debug/profiling/*` don't exist in the running application

## Changes Made

Removed from `docs/configuration.md`:
1. `performance.memory.profiling` configuration section (lines 780-784)
2. `profiling: true` reference in debug endpoints list (line 887)
3. Entire "Collection Profiling" section (lines 892-916)

## Note

- `docs/profiling.md` is in `.gitignore` (line 105) and was never tracked in the repository
- Performance monitoring via `/debug/performance` remains fully functional and documented
- For current monitoring capabilities, see `docs/performance-monitoring.md`